### PR TITLE
Improve translations quality formatting the text passed to Bing Translator

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -29,7 +29,7 @@
 		$('.vex-dialog-buttons').append($translate);
 
 		$translate.on('click', function() {
-			window.open('http://www.bing.com/translator/?from=en&to=es&text=' + encodeURI($('.vex-dialog-message').text()));
+		    window.open('http://www.bing.com/translator/?from=en&to=es&text=' + encodeURI($('.vex-dialog-message').context.body.lastChild.innerText));
 		});
 	});
 


### PR DESCRIPTION
The actual version of verb-tenses sent to Bing Translator the text:

> Permanent situationsShe works in a bank.Generally trueThe sun rises in the east.HabitsI play tennis every Tuesday.Future TimetablesOur train leaves at 11 am.Future after when, until, ...I won't go until it stops raining.

Applying this commit, the text sent (IExplorer 10) to Bing Translator will be:

> Permanent situations
> She works in a bank.
> Generally true
> The sun rises in the east.
> Habits
> I play tennis every Tuesday.
> Future Timetables
> Our train leaves at 11 am.
> Future after when, until, ...
> I won't go until it stops raining.

... and on Chrome will be...

> Permanent situations
> She works in a bank.
> 
> Generally true
> The sun rises in the east.
> 
> Habits
> I play tennis every Tuesday.
> 
> Future Timetables
> Our train leaves at 11 am.
> 
> Future after when, until, ...
> I won't go until it stops raining.
